### PR TITLE
Implement automatic refresh token handling

### DIFF
--- a/src/main/java/com/lgcns/theseven/modules/auth/api/controller/AuthController.java
+++ b/src/main/java/com/lgcns/theseven/modules/auth/api/controller/AuthController.java
@@ -72,6 +72,12 @@ public class AuthController {
                 .path("/")
                 .maxAge(Duration.ofSeconds(jwtTokenProvider.getAccessTokenValidity()))
                 .build();
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", auth.getRefreshToken())
+                .httpOnly(true)
+                .path("/")
+                .maxAge(Duration.ofSeconds(jwtTokenProvider.getRefreshTokenValidity()))
+                .build();
         response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
     }
 }

--- a/src/main/java/com/lgcns/theseven/modules/auth/infrastructure/config/JwtTokenFilter.java
+++ b/src/main/java/com/lgcns/theseven/modules/auth/infrastructure/config/JwtTokenFilter.java
@@ -2,10 +2,14 @@ package com.lgcns.theseven.modules.auth.infrastructure.config;
 
 import com.lgcns.theseven.common.jwt.JwtTokenProvider;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -15,45 +19,117 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 
 public class JwtTokenFilter extends OncePerRequestFilter {
     private final JwtTokenProvider tokenProvider;
+    private final StringRedisTemplate redisTemplate;
 
-    public JwtTokenFilter(JwtTokenProvider tokenProvider) {
+    public JwtTokenFilter(JwtTokenProvider tokenProvider, StringRedisTemplate redisTemplate) {
         this.tokenProvider = tokenProvider;
+        this.redisTemplate = redisTemplate;
     }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        String header = request.getHeader("Authorization");
-        String token = null;
-        if (StringUtils.hasText(header) && header.startsWith("Bearer ")) {
-            token = header.substring(7);
-        } else if (request.getCookies() != null) {
-            for (var cookie : request.getCookies()) {
-                if ("accessToken".equals(cookie.getName())) {
-                    token = cookie.getValue();
-                    break;
-                }
-            }
-        }
+        String token = extractAccessToken(request);
+        Claims claims = null;
+        boolean expired = false;
         if (token != null) {
             try {
-                Claims claims = tokenProvider.parseToken(token);
-                UserDetails userDetails = User.withUsername(claims.getSubject())
-                        .password("")
-                        .authorities(((List<String>) claims.get("roles", List.class)).toArray(new String[0]))
-                        .build();
-                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                        userDetails, null, userDetails.getAuthorities());
-                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                claims = tokenProvider.parseToken(token);
+            } catch (ExpiredJwtException e) {
+                claims = e.getClaims();
+                expired = true;
             } catch (Exception e) {
                 logger.warn("JWT Authentication failed: " + e.getMessage());
             }
         }
+
+        if (claims != null && expired) {
+            String refresh = extractRefreshToken(request);
+            if (refresh != null) {
+                String key = "refreshToken:" + refresh;
+                String userId = redisTemplate.opsForValue().get(key);
+                if (userId != null && userId.equals(claims.getSubject())) {
+                    redisTemplate.delete(key);
+                    String newAccess = tokenProvider.generateAccessToken(
+                            claims.getSubject(),
+                            Map.of("roles", claims.get("roles", List.class))
+                    );
+                    String newRefresh = tokenProvider.generateRefreshToken(claims.getSubject());
+                    redisTemplate.opsForValue().set(
+                            "refreshToken:" + newRefresh,
+                            claims.getSubject(),
+                            Duration.ofSeconds(tokenProvider.getRefreshTokenValidity()));
+
+                    ResponseCookie accessCookie = ResponseCookie.from("accessToken", newAccess)
+                            .httpOnly(true)
+                            .path("/")
+                            .maxAge(Duration.ofSeconds(tokenProvider.getAccessTokenValidity()))
+                            .build();
+                    ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", newRefresh)
+                            .httpOnly(true)
+                            .path("/")
+                            .maxAge(Duration.ofSeconds(tokenProvider.getRefreshTokenValidity()))
+                            .build();
+                    response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+                    response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+
+                    token = newAccess;
+                    claims = tokenProvider.parseToken(newAccess);
+                    expired = false;
+                } else {
+                    claims = null;
+                }
+            } else {
+                claims = null;
+            }
+        }
+
+        if (claims != null && !expired) {
+            UserDetails userDetails = User.withUsername(claims.getSubject())
+                    .password("")
+                    .authorities(((List<String>) claims.get("roles", List.class)).toArray(new String[0]))
+                    .build();
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                    userDetails, null, userDetails.getAuthorities());
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
         filterChain.doFilter(request, response);
+    }
+
+    private String extractAccessToken(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (StringUtils.hasText(header) && header.startsWith("Bearer ")) {
+            return header.substring(7);
+        } else if (request.getCookies() != null) {
+            for (var cookie : request.getCookies()) {
+                if ("accessToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    private String extractRefreshToken(HttpServletRequest request) {
+        String header = request.getHeader("Refresh-Token");
+        if (StringUtils.hasText(header)) {
+            return header;
+        }
+        if (request.getCookies() != null) {
+            for (var cookie : request.getCookies()) {
+                if ("refreshToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/com/lgcns/theseven/modules/auth/infrastructure/config/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/lgcns/theseven/modules/auth/infrastructure/config/OAuth2LoginSuccessHandler.java
@@ -52,7 +52,13 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                 .path("/")
                 .maxAge(Duration.ofSeconds(tokenProvider.getAccessTokenValidity()))
                 .build();
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refresh)
+                .httpOnly(true)
+                .path("/")
+                .maxAge(Duration.ofSeconds(tokenProvider.getRefreshTokenValidity()))
+                .build();
         response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
         response.addHeader("Refresh-Token", refresh);
 
         String targetUrl = "/test/public";

--- a/src/main/java/com/lgcns/theseven/modules/auth/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/lgcns/theseven/modules/auth/infrastructure/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.lgcns.theseven.modules.auth.infrastructure.config;
 import com.lgcns.theseven.common.jwt.JwtTokenProvider;
 import com.lgcns.theseven.modules.auth.application.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -20,6 +21,7 @@ public class SecurityConfig {
     private final JwtTokenProvider tokenProvider;
     private final CustomOAuth2UserService oAuth2UserService;
     private final OAuth2LoginSuccessHandler successHandler;
+    private final StringRedisTemplate redisTemplate;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -37,7 +39,7 @@ public class SecurityConfig {
                         .userInfoEndpoint(info -> info.userService(oAuth2UserService))
                         .successHandler(successHandler)
                 )
-                .addFilterBefore(new JwtTokenFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtTokenFilter(tokenProvider, redisTemplate), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 


### PR DESCRIPTION
## Summary
- store refresh token in cookies for login flows
- include redis cache in JWT filter and automatically refresh token
- update OAuth success handler to set refresh cookie
- wire redis template into security config for new filter

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_68504163c520832a9bf420185e2a36cd